### PR TITLE
feat: add MiniMax AI model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ python main.py --preset 8 --rounds 1 --debug
 | GROK | xAI Grok | grok-3 |
 | LLAMA | Meta Llama | llama3-70b-8192 |
 | KIMI | Moonshot Kimi | kimi-k2-0711-preview |
+| MINIMAX | MiniMax | Minimax-M2.7 |
 
 ### 预设游戏配置
 

--- a/config/ai_config.example.json
+++ b/config/ai_config.example.json
@@ -4,6 +4,14 @@
     "export_format": ["json"]
   },
   "ai_players": {
+    "MINIMAX": {
+      "baseurl": "https://api.minimax.chat/v1",
+      "api_key": "your-minimax-api-key",
+      "model": "Minimax-M2.7",
+      "show_reasoning": true,
+      "retry_attempts": 3,
+      "timeout": 30
+    },
     "GPT4O": {
       "baseurl": "https://your-api-endpoint.com/v1",
       "api_key": "your-api-key-here",


### PR DESCRIPTION
Add MiniMax as a supported AI model in the werewolf game simulator.

## Changes
- Add MINIMAX entry to `config/ai_config.example.json` with `Minimax-M2.7` model
- Update README.md model table with MINIMAX support

## Testing
Users can now configure MiniMax as an AI player by adding their API key to the config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)